### PR TITLE
Updates to Search and Date Format Default

### DIFF
--- a/jupyter_alabaster_theme/__init__.py
+++ b/jupyter_alabaster_theme/__init__.py
@@ -66,3 +66,5 @@ html_additional_pages = {
     'searchresults': 'custom_searchresults.html',
     'custom_search': 'custom_search.html'
 }
+
+html_last_updated_fmt = "%a, %b %d, %Y"

--- a/jupyter_alabaster_theme/jupyter/custom_search.html
+++ b/jupyter_alabaster_theme/jupyter/custom_search.html
@@ -34,11 +34,6 @@
     function will automatically search for all of the words. Pages
     containing fewer words won't appear in the result list.{% endtrans %}
   </p>
-  <form action="" method="get">
-    <input type="text" name="q" value="" />
-    <input class="searchbox-button" type="submit" />
-    <span id="search-progress" style="padding-left: 10px"></span>
-  </form>
   {% if search_performed %}
     <h2>{{ _('Search Results') }}</h2>
     {% if not search_results %}

--- a/jupyter_alabaster_theme/jupyter/custom_searchbox.html
+++ b/jupyter_alabaster_theme/jupyter/custom_searchbox.html
@@ -7,7 +7,6 @@
     :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 #}
-{%- if pagename != "custom_search" and builder != "singlehtml" %}
 <div id="searchbox" style="display: none" role="search">
     <form class="search" action="{{ pathto('custom_search') }}" method="get">
       <div>
@@ -19,4 +18,3 @@
     </form>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script>
-{%- endif %}

--- a/jupyter_alabaster_theme/jupyter/navbar.html
+++ b/jupyter_alabaster_theme/jupyter/navbar.html
@@ -54,6 +54,9 @@
                     <li class="docs-breadcrumb-item"><a href="https://jupyter.org"><img src="{{ pathto("_static/_images/jupytertheme-images/breadcrumb-home.svg", 1) }}" / class="breadcrumb-home"></a><img src="{{ pathto("_static/_images/jupytertheme-images/breadcrumb-separator.svg", 1) }}" class="breadcrumb-separator"/></li>
                     {% if title == project %}
                     <li class="docs-breadcrumb-item"><a href="{{ pathto(master_doc) }}"> {{ project }}</a></li>
+                    {% elif pagename == 'custom_search' %}
+                    <li class="docs-breadcrumb-item"><a href="{{ pathto(master_doc) }}"> {{ project }}</a><img src="{{ pathto("_static/_images/jupytertheme-images/breadcrumb-separator.svg", 1) }}" class="breadcrumb-separator"/></li>
+                    <li class="docs-breadcrumb-item">Search</li>
                     {% else %}
                       <li class="docs-breadcrumb-item"><a href="{{ pathto(master_doc) }}"> {{ project }}</a><img src="{{ pathto("_static/_images/jupytertheme-images/breadcrumb-separator.svg", 1) }}" class="breadcrumb-separator"/></li>
                       {% for doc in parents %}


### PR DESCRIPTION
- Search page does not have extra breadcrumb separator
- search box is removed from search page but search box in the sidebar is kept for consistency
- default date time format is DayofWeek, Month, DayofMonth, Year. 

Sidenote: This can also be overrided by the user if they want to use a different format in `conf.py`