### PR TITLE
fix CSS animation issue with jQuery script not executing

### DIFF
--- a/jupyter_alabaster_theme/jupyter/static/js/mobile-nav.js
+++ b/jupyter_alabaster_theme/jupyter/static/js/mobile-nav.js
@@ -1,4 +1,4 @@
-$(document).on('ready', function() {
+$(function() {
     $('.mobile-nav-section, .mobile-nav-current-dropdown').on('click', function() {
         var openToggle = $(this).find('.mobile-nav-expand-icon');
         if (openToggle.hasClass('close-icon')) {


### PR DESCRIPTION
- jQuery's `$(document).on('ready'....)` has been deprecated as of jQuery 3.0 which lead to the script not working and CSS classes not being modified for animations to occur
- `$(function() {}` maps to `$( document ).ready(function(){});`

Source: https://api.jquery.com/ready/