### PR TITLE
Mobile Side Bar works with out Captions in the toctree

### DIFF
--- a/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
+++ b/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
@@ -21,7 +21,7 @@
     </div>
   </div>
 
-  <div id="sectionList">
+  <div id="sectionList" class="collapse">
     {# Skip the first section as it is a '\n' resulting from splitting the string #}
     {% for section in list[1:] %}
       {# Split each 1st level child into subSections that may contain a 2nd level children #}

--- a/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
+++ b/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
@@ -1,5 +1,6 @@
 {% set theTocTree = toctree(includehidden=theme_sidebar_includehidden, collapse=False, maxdepth=2)
   | replace('<ul class="current">', "", 1)
+  | replace('<ul class="current">', "Second ")
   | replace('<ul>', "Second ")
   | replace('</ul>', "")
   | replace('<li class="toctree-l1 current">', "First ")
@@ -7,13 +8,16 @@
   | replace('</li>', "")
 %}
 
-
 <div>
   {# Start by splitting the TocTree by 1st level children #}
   {% set list = theTocTree.split("First ") %}
   <div class="mobile-nav-current-dropdown" data-toggle = "collapse" data-target = "#sectionList">
     <div class="mobile-nav-current">
-      <h3 class="mobile-nav-current-section">User Documentation</h3>
+      {% if parents|length >= 1 %}
+        <h3 class="mobile-nav-current-section"> {{ parents[0].title }} </h3>
+      {% else %}
+        <h3 class="mobile-nav-current-section"> {{ title }} </h3>
+      {% endif %}
       <h2 class="mobile-nav-current-page"> {{ title }} </h2>
     </div>
     <div class="top-mobile-nav-expand">

--- a/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
+++ b/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
@@ -1,12 +1,16 @@
-{% set theTocTree = toctree(collapse = False, maxdepth = 1)
-  | replace('<p class="caption">', "Header: ")
-  | replace('</p>', "")
-  | replace("<ul>", "List: ")
-  | replace('<ul class="current">', "List: ")
-  | replace("</ul>", "")
+{% set theTocTree = toctree(includehidden=theme_sidebar_includehidden, collapse=False, maxdepth=2)
+  | replace('<ul class="current">', "", 1)
+  | replace('<ul>', "Second ")
+  | replace('</ul>', "")
+  | replace('<li class="toctree-l1 current">', "First ")
+  | replace('<li class="toctree-l1">', "First ")
+  | replace('</li>', "")
 %}
+
+
 <div>
-  {% set list = theTocTree.split("Header: ") %}
+  {# Start by splitting the TocTree by 1st level children #}
+  {% set list = theTocTree.split("First ") %}
   <div class="mobile-nav-current-dropdown" data-toggle = "collapse" data-target = "#sectionList">
     <div class="mobile-nav-current">
       <h3 class="mobile-nav-current-section">User Documentation</h3>
@@ -16,26 +20,46 @@
       <img class="mobile-nav-expand-icon" src="{{ pathto("_static/_images/jupytertheme-images/expand.svg", 1) }}" alt="expand icon"/>
     </div>
   </div>
-  <div  id="sectionList" class = "collapse">
-  {% for section in list[1:] %}
-    {% set subSection = section.split("List: ") %}
-    <div class = "dropdown">
-      {% set headerTarget = "heading" ~ loop.index %}
-      {% for item in subSection %}
-        {% if loop.index == 1 %}
-        <div type = "button" class = "btn dropdown mobile-nav-section" data-toggle = "collapse" data-target = "{{ "." ~ headerTarget }}">
-          <h3 class="mobile-nav-header"> {{ item | striptags }}</h3>
-          <div class="mobile-nav-expand">
-            <img class="mobile-nav-expand-icon" src="{{ pathto("_static/_images/jupytertheme-images/expand.svg", 1) }}" alt="expand icon"/>
-          </div>
-        </div>
-        {% else %}
-        <ul class = "{{ headerTarget ~ " collapse mobile-nav-items" }}">
-          {{ item }}
-        </ul>
-        {% endif %}
-      {% endfor %}
-    </div>
-  {% endfor %}
+
+  <div id="sectionList">
+    {# Skip the first section as it is a '\n' resulting from splitting the string #}
+    {% for section in list[1:] %}
+      {# Split each 1st level child into subSections that may contain a 2nd level children #}
+      {% set subSection = section.split("Second ") %}
+      <div class="dropdown">
+        {% set headerTarget = "heading" ~ loop.index %}
+        {% for item in subSection %}
+          {# first (and only) item is a 1st level child #}
+          {% if subSection|length == 1 %}
+            <div type = "button" class = "btn dropdown mobile-nav-section" data-toggle = "collapse" data-target = "{{ "." ~ headerTarget }}">
+              <h3 class="mobile-nav-header"> {{ item | striptags }}</h3>
+              <div class="mobile-nav-expand">
+                <img class="mobile-nav-expand-icon" src="{{ pathto("_static/_images/jupytertheme-images/expand.svg", 1) }}" alt="expand icon"/>
+              </div>
+            </div>
+            <ul class = "{{ headerTarget ~ " collapse mobile-nav-items" }}">
+              <li class = "toctree-l2">
+                {{ item }}
+              </li>
+            </ul>
+          {% elif loop.index == 1 %}
+            <div type = "button" class = "btn dropdown mobile-nav-section" data-toggle = "collapse" data-target = "{{ "." ~ headerTarget }}">
+              <h3 class="mobile-nav-header"> {{ item | striptags }}</h3>
+              <div class="mobile-nav-expand">
+                <img class="mobile-nav-expand-icon" src="{{ pathto("_static/_images/jupytertheme-images/expand.svg", 1) }}" alt="expand icon"/>
+              </div>
+            </div>
+          {# all other children are 2nd level children #}
+          {% else %}
+            <ul class = "{{ headerTarget ~ " collapse mobile-nav-items" }}">
+              <li class = "toctree-l2">
+                {{ subSection[0] }}
+              </li>
+              {{ item }}
+            </ul>
+          {% endif %}
+        {% endfor %}
+      </div>
+    {% endfor %}
   </div>
 </div>

--- a/jupyter_alabaster_theme/jupyter/static/css/jupytertheme.css
+++ b/jupyter_alabaster_theme/jupyter/static/css/jupytertheme.css
@@ -427,6 +427,11 @@ p.caption {
   font-weight: 500;
 }
 
+.mobile-nav-items .toctree-l2 .current {
+  color: #F37726;
+  font-weight: 500;
+}
+
 .top-mobile-nav-expand {
   float: right;
   /* 17.5px is half of the height of the top navigation box */
@@ -455,6 +460,13 @@ p.caption {
 }
 
 .toctree-l1 > a.reference {
+  color: #757575;
+  font-size: 18px;
+  text-decoration: none;
+  border-bottom: none;
+}
+
+.toctree-l2 > a.reference {
   color: #757575;
   font-size: 18px;
   text-decoration: none;


### PR DESCRIPTION
This sidebar is modeled after the [IPython documentation site](http://ipython.readthedocs.io/en/stable/index.html) as it has no captions in its toctree but also has sub-sections for each level 1 child.