### PR TITLE
fix word-wrap problem in Mobile Sidebar Section Names

### DIFF
--- a/jupyter_alabaster_theme/jupyter/static/css/jupytertheme.css
+++ b/jupyter_alabaster_theme/jupyter/static/css/jupytertheme.css
@@ -418,6 +418,8 @@ p.caption {
     font-size: 20px;
     margin: 12px 0px;
     float: left;
+    text-align: left;
+    white-space: normal;
 }
 
 .mobile-nav-items {


### PR DESCRIPTION
Closes #28 
Bootstrap's `btn` class was setting `whites-space: nowrap` removing line breaks. I added back `white-space: normal` to override it. Also added `text-align:left` because the `btn` class was setting it to center.