### PR TITLE
single sections no longer have a dropdown

### DIFF
--- a/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
+++ b/jupyter_alabaster_theme/jupyter/mobile_sidebar.html
@@ -16,7 +16,7 @@
       {% if parents|length >= 1 %}
         <h3 class="mobile-nav-current-section"> {{ parents[0].title }} </h3>
       {% else %}
-        <h3 class="mobile-nav-current-section"> {{ title }} </h3>
+        <h3 class="mobile-nav-current-section"> {{ project }} </h3>
       {% endif %}
       <h2 class="mobile-nav-current-page"> {{ title }} </h2>
     </div>
@@ -35,17 +35,11 @@
         {% for item in subSection %}
           {# first (and only) item is a 1st level child #}
           {% if subSection|length == 1 %}
-            <div type = "button" class = "btn dropdown mobile-nav-section" data-toggle = "collapse" data-target = "{{ "." ~ headerTarget }}">
-              <h3 class="mobile-nav-header"> {{ item | striptags }}</h3>
-              <div class="mobile-nav-expand">
-                <img class="mobile-nav-expand-icon" src="{{ pathto("_static/_images/jupytertheme-images/expand.svg", 1) }}" alt="expand icon"/>
-              </div>
-            </div>
-            <ul class = "{{ headerTarget ~ " collapse mobile-nav-items" }}">
-              <li class = "toctree-l2">
+            <div type = "button" class = "btn mobile-nav-section">
+              <h3 class="mobile-nav-header">
                 {{ item }}
-              </li>
-            </ul>
+              </h3>
+            </div>
           {% elif loop.index == 1 %}
             <div type = "button" class = "btn dropdown mobile-nav-section" data-toggle = "collapse" data-target = "{{ "." ~ headerTarget }}">
               <h3 class="mobile-nav-header"> {{ item | striptags }}</h3>

--- a/jupyter_alabaster_theme/jupyter/static/css/jupytertheme.css
+++ b/jupyter_alabaster_theme/jupyter/static/css/jupytertheme.css
@@ -422,6 +422,18 @@ p.caption {
     white-space: normal;
 }
 
+h3.mobile-nav-header a {
+  text-decoration: none;
+  border: none;
+  outline: none;
+  color: inherit;
+}
+
+h3.mobile-nav-header a:hover {
+  outline: none;
+  border: none;
+}
+
 .mobile-nav-items {
   padding-left: 16px;
 }


### PR DESCRIPTION
As I was thinking about theme documentation, I noticed there was a need for sections with only one page. In that case, I made the section clickable and if you are on the page, the top navigation will use project name. This also avoids the situation where you have both section name and `pagename` to be the same.