### PR TITLE
Give user ability to configure maxdepth

### DIFF
--- a/jupyter_alabaster_theme/jupyter/custom_navigation.html
+++ b/jupyter_alabaster_theme/jupyter/custom_navigation.html
@@ -2,7 +2,7 @@
   <a href="{{ pathto(master_doc) }}">{{ project }}</a>
 </h1>
 {% include "custom_searchbox.html" %}
-{{ toctree(includehidden=theme_sidebar_includehidden, collapse=theme_sidebar_collapse, maxdepth=2) }}
+{{ toctree(includehidden=theme_sidebar_includehidden, collapse=theme_sidebar_collapse, maxdepth=(theme_sidebar_maxdepth|int)) }}
 {% if theme_extra_nav_links %}
 <hr />
 <ul>

--- a/jupyter_alabaster_theme/jupyter/theme.conf
+++ b/jupyter_alabaster_theme/jupyter/theme.conf
@@ -25,6 +25,7 @@ canonical_url =
 extra_nav_links =
 sidebar_includehidden = true
 sidebar_collapse = true
+sidebar_maxdepth = 2
 show_powered_by = true
 show_related = false
 


### PR DESCRIPTION
This functionality isn't in Alabaster's `html_theme_options` attributes that can be set by the user.

We did however support this in the `jupyter-sphinx-theme` albeit with a default value of 1.
https://github.com/jupyter/jupyter-sphinx-theme/blob/master/jupyter_sphinx_theme/jupyter/globaltoc.html#L9
https://github.com/jupyter/jupyter-sphinx-theme/blob/master/jupyter_sphinx_theme/jupyter/theme.conf#L30

It is set to 2 for now and can be changed by the user's `conf.py` under `html_theme_options`.