### PR TITLE
Add a Docs badge and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ dist
 *\.egg-info
 demo/build/*
 node_modules
+npm-debug.log
 __pycache__

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Jupyter Alabaster Theme
 
+[![Documentation Status](http://readthedocs.org/projects/jupyter-alabaster-theme/badge/?version=latest)](http://jupyter-alabaster-theme.readthedocs.io/en/latest/?badge=latest)
+
 A Sphinx theme for Jupyter based on the [Alabaster theme](https://alabaster.readthedocs.io/en/latest/).
 
 To use this theme on any Sphinx based documentation, follow these steps:
@@ -56,4 +58,3 @@ To get your documentation to build, you will need to update its build dependenci
 If you have questions about this project, please go to our Gitter channel:
 
 https://gitter.im/jupyter/jupyter
-


### PR DESCRIPTION
- Docs badge will allow easy access to theme documentation from GitHub repo
- npm-debug.log does not need to be tracked