### PR TITLE
CSS fixes from sidebar and navbar

### DIFF
--- a/jupyter_alabaster_theme/static/css/navbar.css
+++ b/jupyter_alabaster_theme/static/css/navbar.css
@@ -14,7 +14,7 @@
 .navbar-fixed-top .nav {
   padding: 15px 0
 }
-.navbar-navbar-fixed-top .navbar-brand {
+.navbar-fixed-top .navbar-brand {
   padding: 0 15px
 }
 .navbar-header .icon-bar {

--- a/jupyter_alabaster_theme/static/css/sidebar.css
+++ b/jupyter_alabaster_theme/static/css/sidebar.css
@@ -122,7 +122,16 @@
     margin-left: 0px;
 }
 
-.docs-breadcrumbs-item a {
+.docs-breadcrumb-item {
+  list-style-type: none;
+  display: inline;
+  color: white;
+  font-size: 16px;
+  line-height: 2.2;
+  height: 24px
+}
+
+.docs-breadcrumb-item a {
     color: white;
     letter-spacing: .8px;
 }

--- a/jupyter_alabaster_theme/static/pcss/navbar.pcss
+++ b/jupyter_alabaster_theme/static/pcss/navbar.pcss
@@ -17,7 +17,7 @@
       padding: 15px 0;
     }
 
-    &-navbar-fixed-top &-brand {
+    &-fixed-top &-brand {
       padding: 0 15px;
     }
 

--- a/jupyter_alabaster_theme/static/pcss/sidebar.pcss
+++ b/jupyter_alabaster_theme/static/pcss/sidebar.pcss
@@ -118,8 +118,17 @@
   & ul {
     margin-left: 0px;
   }
+}
 
-  &-item a {
+.docs-breadcrumb-item {
+  list-style-type: none;
+  display: inline;
+  color: white;
+  font-size: 16px;
+  line-height: 2.2;
+  height: 24px;
+
+  & a {
     color: white;
     letter-spacing: .8px;
   }


### PR DESCRIPTION
Things left out from #61 
`docs-breadcrumb-item` was left out accidentally 
https://github.com/jupyter/jupyter-alabaster-theme/blob/c034ffa218651bdbf9dbc6185514af70598c2100/jupyter_alabaster_theme/static/css/jupytertheme.css#L613

`navbar-fixed-top` class was misnamed here with two `-navbar`
https://github.com/jupyter/jupyter-alabaster-theme/blob/1e2ca1c9e2b1e2958a380fc225e57b410496210b/jupyter_alabaster_theme/static/css/navbar.css#L17