### PR TITLE
use alabaster.css and pygments_style

### DIFF
--- a/jupyter_alabaster_theme/static/index.css
+++ b/jupyter_alabaster_theme/static/index.css
@@ -1,3 +1,4 @@
+@import 'alabaster.css';
 @import 'css/bootstrap.min.css';
 @import 'css/jupytertheme.css';
 @import 'css/navbar.css';

--- a/jupyter_alabaster_theme/static/index.css
+++ b/jupyter_alabaster_theme/static/index.css
@@ -1,7 +1,8 @@
-// Import CSS from inherited theme alabaster
+//Import Bootstrap first
+@import 'css/bootstrap.min.css';
+// Import CSS from inherited theme alabaster, this also overrides bootstrap defaults
 @import 'alabaster.css';
 // Import other CSS files
-@import 'css/bootstrap.min.css';
 @import 'css/jupytertheme.css';
 @import 'css/navbar.css';
 @import 'css/footer.css';

--- a/jupyter_alabaster_theme/static/index.css
+++ b/jupyter_alabaster_theme/static/index.css
@@ -1,4 +1,6 @@
+// Import CSS from inherited theme alabaster
 @import 'alabaster.css';
+// Import other CSS files
 @import 'css/bootstrap.min.css';
 @import 'css/jupytertheme.css';
 @import 'css/navbar.css';

--- a/jupyter_alabaster_theme/theme.conf
+++ b/jupyter_alabaster_theme/theme.conf
@@ -1,7 +1,7 @@
 [theme]
 inherit = alabaster
 stylesheet = index.css
-
+pygments_style = alabaster
 
 [options]
 sidebar_maxdepth = 2


### PR DESCRIPTION
Simply inheriting from `alabaster` does not include it's CSS.  Also added a `pygments_style` value 

Before:
![screen shot 2017-05-03 at 2 57 27 pm](https://cloud.githubusercontent.com/assets/16314651/25683661/1dbad4aa-3012-11e7-9718-331463b31483.png)


Adding this change produces the following result:
![screen shot 2017-05-03 at 3 01 24 pm](https://cloud.githubusercontent.com/assets/16314651/25683664/217c80c0-3012-11e7-8351-29a334770f8d.png)