### PR TITLE
use npm-run-all and update development docs

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -47,7 +47,11 @@ To Add a Post CSS file:
 3. In ``package.json`` add a script with a name ``css:foo`` and action
    ``"postcss jupyter_alabaster_theme/static/pcss/foo.pcss -o jupyter_alabaster_theme/static/css/foo.css",``
 
-4. Update ``css`` script in ``package.json`` to include ``npm run css:foo``.
+Installing Post CSS and other npm dependencies
+
+.. code::
+
+    npm install
 
 To compile Post CSS into CSS:
 

--- a/package.json
+++ b/package.json
@@ -1,23 +1,24 @@
 {
-    "scripts": {
-        "css:navbar": "postcss jupyter_alabaster_theme/static/pcss/navbar.pcss -o jupyter_alabaster_theme/static/css/navbar.css",
-        "css:footer": "postcss jupyter_alabaster_theme/static/pcss/footer.pcss -o jupyter_alabaster_theme/static/css/footer.css",
-        "css:search": "postcss jupyter_alabaster_theme/static/pcss/search.pcss -o jupyter_alabaster_theme/static/css/search.css",
-        "css:jupytertheme": "postcss jupyter_alabaster_theme/static/pcss/jupytertheme.pcss -o jupyter_alabaster_theme/static/css/jupytertheme.css",
-        "css:mobile_sidebar": "postcss jupyter_alabaster_theme/static/pcss/mobile_sidebar.pcss -o jupyter_alabaster_theme/static/css/mobile_sidebar.css",
-        "css:sidebar": "postcss jupyter_alabaster_theme/static/pcss/sidebar.pcss -o jupyter_alabaster_theme/static/css/sidebar.css",
-        "css:mediaqueries": "postcss jupyter_alabaster_theme/static/pcss/mediaqueries.pcss -o jupyter_alabaster_theme/static/css/mediaqueries.css",
-        "css": "npm run css:navbar && npm run css:footer && npm run css:search && npm run css:jupytertheme && npm run css:mobile_sidebar && npm run css:sidebar && npm run css:mediaqueries"
-    },
-    "dependencies": {},
-    "devDependencies": {
-        "postcss": "^5.2.17",
-        "postcss-cli": "^3.2.0",
-        "postcss-cssnext": "^2.10.0"
-    },
-    "postcss": {
-        "plugins": {
-            "postcss-cssnext": {}
-        }
+  "scripts": {
+    "css:navbar": "postcss jupyter_alabaster_theme/static/pcss/navbar.pcss -o jupyter_alabaster_theme/static/css/navbar.css",
+    "css:footer": "postcss jupyter_alabaster_theme/static/pcss/footer.pcss -o jupyter_alabaster_theme/static/css/footer.css",
+    "css:search": "postcss jupyter_alabaster_theme/static/pcss/search.pcss -o jupyter_alabaster_theme/static/css/search.css",
+    "css:jupytertheme": "postcss jupyter_alabaster_theme/static/pcss/jupytertheme.pcss -o jupyter_alabaster_theme/static/css/jupytertheme.css",
+    "css:mobile_sidebar": "postcss jupyter_alabaster_theme/static/pcss/mobile_sidebar.pcss -o jupyter_alabaster_theme/static/css/mobile_sidebar.css",
+    "css:sidebar": "postcss jupyter_alabaster_theme/static/pcss/sidebar.pcss -o jupyter_alabaster_theme/static/css/sidebar.css",
+    "css:mediaqueries": "postcss jupyter_alabaster_theme/static/pcss/mediaqueries.pcss -o jupyter_alabaster_theme/static/css/mediaqueries.css",
+    "css": "npm-run-all css:*"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "npm-run-all": "^4.0.2",
+    "postcss": "^5.2.17",
+    "postcss-cli": "^3.2.0",
+    "postcss-cssnext": "^2.10.0"
+  },
+  "postcss": {
+    "plugins": {
+      "postcss-cssnext": {}
     }
+  }
 }


### PR DESCRIPTION
`npm-run-all` simplifies the building of CSS and removes the need to do multiple `npm run css:foo.css && npm run css:....etc` commands in the scripts