### PR TITLE
simplify where install directions are

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,52 +6,10 @@ A Sphinx theme for Jupyter based on the [Alabaster theme](https://alabaster.read
 
 To use this theme on any Sphinx based documentation, follow these steps:
 
-## Installation
+## Installation and Configuration
 
-Install the `jupyter_alabaster_theme` package using pip:
-
-```bash
-pip install jupyter_alabaster_theme
-```
-
-## Configuration
-
-To use the theme in your Sphinx based documentation, follow these steps. For further
-details, see the documentation for this theme [here](http://jupyter-alabaster-theme.readthedocs.io/en/latest/).
-
-### Edit `conf.py`
-
-Most of the work to use the theme is in editing your `conf.py` file that configures
-Sphinx.
-
-First, You will need to set the theme itself to `jupyter_alabaster_theme`:
-
-```python
-html_theme = 'jupyter_alabaster_theme'
-```
-
-Second, you will need to add `jupyter_alabaster_theme` to the list of extensions:
-
-```python
-extensions = [
-    ...
-    'jupyter_alabaster_theme',
-]
-```
-
-Finally, at the bottom of `conf.py`, the following block of code, if present, should be removed:
-
-```python
-if not on_rtd:
-    # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-```
-
-### Update documentation dependencies
-
-To get your documentation to build, you will need to update its build dependencies. Update your `environment.yml` or `requirements.txt` to depend on  `jupyter_alabaster_theme` to get the build working on ReadTheDocs. Note, we have not yet released a [Conda](https://conda.io/docs/intro.html) package for this theme, so you will need to list it in the `environment.yml` file under the `pip` section.
+To use the theme in your Sphinx based documentation, the steps detailed
+ [here](http://jupyter-alabaster-theme.readthedocs.io/en/latest/user.html#how-to-install).
 
 ## Questions
 

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -80,6 +80,8 @@ file under the ``pip`` section.
 
 Important Notes
 ================
+* Use one ``toctree`` in your index.rst. More toctrees can be added within sections
+  that are included in the main ``toctree``.
 * Avoid using ``captions`` in the ``toctree`` since that is not accessible to mobile
   navigation menus and the breadcrumbs.
 * Avoid adding subsections that are on the same page as the section to the ``toctree``.
@@ -97,13 +99,3 @@ Important Notes
 
 * More information about the ``toctree`` can be found at the `Sphinx documentation
   site <http://www.sphinx-doc.org/en/stable/markup/toctree.html>`_
-
-* The theme itself sets ``html_sidebars`` to include a custom sidebar navigation
-  template. If you want to use different sidebar templates, simply set your own
-  in ``conf.py``, to override the theme's defaults. Otherwise you can add more by:
-
-.. code::
-
-    html_sidebars.update(
-      # Additional sidebars can be added here
-    )


### PR DESCRIPTION
- Removed details concerning `html_sidebars` since we account for that case by automatically updating the sidebar templates here:
https://github.com/jupyter/jupyter-alabaster-theme/blob/master/jupyter_alabaster_theme/__init__.py#L35
- add requirement of using only one `toctree` in documentation
- installation/configuration instructions can change. It's easier to maintain if we put them in one spot